### PR TITLE
feat: Phase 2 — core MVP (fro check + fro bump)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# All files are owned by @rania-run.
+# Required for branch protection — every PR will request a review from the owner.
+* @rania-run

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+  # Dart pub packages
+  - package-ecosystem: pub
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    assignees:
+      - rania-run
+    labels:
+      - "chore: deps"
+    commit-message:
+      prefix: "chore(deps)"
+
+  # GitHub Actions
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    assignees:
+      - rania-run
+    labels:
+      - "chore: deps"
+    commit-message:
+      prefix: "chore(deps)"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,18 @@
+"type: enhancement":
+  - changed-files:
+    - any-glob-to-any-file: lib/**
+
+"type: testing":
+  - changed-files:
+    - any-glob-to-any-file: test/**
+
+"type: docs":
+  - changed-files:
+    - any-glob-to-any-file:
+      - README.md
+      - CHANGELOG.md
+      - docs/**
+
+"chore: deps":
+  - changed-files:
+    - any-glob-to-any-file: pubspec.yaml

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,10 +1,19 @@
 ## What does this PR do?
 
+<!-- One sentence summary -->
+
 ## Related issue
 Closes #
 
+## Changes
+<!-- Bullet points only — what changed and why -->
+
+## How to test
+<!-- Steps to manually verify this works -->
+
 ## Checklist
-- [ ] `dart analyze` passes
-- [ ] `dart format` applied
-- [ ] Tests added / updated
+- [ ] `dart analyze --fatal-infos` passes
+- [ ] `dart format --set-exit-if-changed .` passes
+- [ ] Tests added / updated for every new behaviour
 - [ ] CHANGELOG updated (for user-facing changes)
+- [ ] No debug code or commented-out blocks left in

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,5 +15,4 @@ Closes #
 - [ ] `dart analyze --fatal-infos` passes
 - [ ] `dart format --set-exit-if-changed .` passes
 - [ ] Tests added / updated for every new behaviour
-- [ ] CHANGELOG updated (for user-facing changes)
 - [ ] No debug code or commented-out blocks left in

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -33,14 +33,33 @@ jobs:
               assignees: [assignee],
             });
 
-      - name: Assign PR to author
+      - name: Assign PR to author and set milestone
         if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
+            const { owner, repo } = context.repo;
+            const prNumber = context.payload.pull_request.number;
+
+            // Assign to the PR author
             await github.rest.issues.addAssignees({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
+              owner, repo,
+              issue_number: prNumber,
               assignees: [context.payload.pull_request.user.login],
             });
+
+            // Set the earliest open milestone
+            const { data: milestones } = await github.rest.issues.listMilestones({
+              owner, repo,
+              state: 'open',
+              sort: 'due_on',
+              direction: 'asc',
+            });
+
+            if (milestones.length > 0) {
+              await github.rest.issues.update({
+                owner, repo,
+                issue_number: prNumber,
+                milestone: milestones[0].number,
+              });
+            }

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -18,19 +18,11 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const labels = context.payload.issue.labels.map(l => l.name);
-
-            // Copilot handles testing and dependency update issues
-            const copilotLabels = ['type: testing', 'chore: deps'];
-            const assignToCopilot = labels.some(l => copilotLabels.includes(l));
-
-            const assignee = assignToCopilot ? 'copilot' : 'rania-run';
-
             await github.rest.issues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              assignees: [assignee],
+              assignees: ['rania-run'],
             });
 
       - name: Assign PR to author and set milestone

--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -1,0 +1,46 @@
+name: Auto Assign
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Assign issue
+        if: github.event_name == 'issues'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = context.payload.issue.labels.map(l => l.name);
+
+            // Copilot handles testing and dependency update issues
+            const copilotLabels = ['type: testing', 'chore: deps'];
+            const assignToCopilot = labels.some(l => copilotLabels.includes(l));
+
+            const assignee = assignToCopilot ? 'copilot' : 'rania-run';
+
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              assignees: [assignee],
+            });
+
+      - name: Assign PR to author
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.addAssignees({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              assignees: [context.payload.pull_request.user.login],
+            });

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,16 @@
+name: Label PR
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/labeler@v5
+        with:
+          configuration-path: .github/labeler.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          # Checks out main so the CHANGELOG commit lands on the branch,
+          # not in a detached-HEAD state at the tag.
+          ref: main
+
+      - name: Generate release notes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh api \
+            --method POST \
+            repos/${{ github.repository }}/releases/generate-notes \
+            -f tag_name="${GITHUB_REF_NAME}" \
+            --jq '.body' > _notes.md
+
+      - name: Update CHANGELOG.md
+        run: |
+          DATE="$(date -u +%Y-%m-%d)"
+          {
+            printf "## [%s] — %s\n\n" "${GITHUB_REF_NAME}" "$DATE"
+            cat _notes.md
+            printf "\n\n---\n\n"
+            [ -f CHANGELOG.md ] && cat CHANGELOG.md || printf "# Changelog\n"
+          } > _tmp.md && mv _tmp.md CHANGELOG.md
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git diff --cached --quiet || {
+            git commit -m "chore: update CHANGELOG for ${GITHUB_REF_NAME} [skip ci]"
+            git push origin HEAD:main
+          }
+          # Note: if this push fails with "protected branch" error, go to
+          # Settings → Branches → edit the main protection rule → add
+          # "github-actions[bot]" under "Allow specified actors to bypass
+          # required pull requests".
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            --title "${GITHUB_REF_NAME}" \
+            --notes-file _notes.md

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ build/
 !.idea/vcs.xml
 !.idea/*.iml
 
+# Local — personal scripts and runbooks, not for the repo
+local/
+
 # Secrets
 .env
 *.env

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ dart pub global activate fro
 # Show current version from pubspec.yaml
 fro check
 
-# Show version from latest git tag (per environment)
-fro check --source=git --env=prod
+# Compare pubspec version against the latest git tag for an environment
+fro check --env=prod
 
 # Bump version and create a git tag
 fro bump --env=prod --strategy=patch   # 1.2.3+45 → 1.2.4+46

--- a/bin/fro.dart
+++ b/bin/fro.dart
@@ -1,11 +1,14 @@
 import 'package:args/command_runner.dart';
+import 'package:fro/commands/bump_command.dart';
 import 'package:fro/commands/check_command.dart';
 
 Future<void> main(List<String> arguments) async {
   final runner = CommandRunner<void>(
     'fro',
     'Flutter release manager — manage versions across environments.',
-  )..addCommand(CheckCommand());
+  )
+    ..addCommand(CheckCommand())
+    ..addCommand(BumpCommand());
 
   await runner.run(arguments);
 }

--- a/docs/github-setup.md
+++ b/docs/github-setup.md
@@ -91,8 +91,7 @@ Runs on every new issue or PR:
 | Event | Assignee |
 |---|---|
 | Issue opened | `rania-run` |
-| PR opened | PR author |
-| PR opened (milestone auto-set) | Earliest open milestone is set automatically |
+| PR opened | PR author; earliest open milestone auto-set |
 
 ---
 

--- a/docs/github-setup.md
+++ b/docs/github-setup.md
@@ -96,9 +96,31 @@ Runs on every new issue or PR:
 
 ---
 
-## Publish Workflow
+## Release Workflow (`.github/workflows/release.yml`)
 
-Defined in `.github/workflows/publish.yml`. Triggers on `v*` tags:
+Triggers on `v*` tag pushes. Steps in order:
+
+1. **Generate notes** — calls the GitHub API to auto-generate release notes from merged PRs since the last tag
+2. **Update CHANGELOG.md** — prepends the new entry and commits it back to `main` with `[skip ci]`
+3. **Create GitHub release** — publishes the release with the generated notes
+
+> **One-time setup required for the CHANGELOG commit:** the `github-actions[bot]` needs permission to push to the protected `main` branch.
+> Go to **Settings → Branches → edit the `main` rule** → under *"Allow specified actors to bypass required pull requests"*, add `github-actions[bot]`.
+
+### Cutting a release
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+Both `publish.yml` (pub.dev) and `release.yml` (GitHub release + CHANGELOG) trigger automatically.
+
+---
+
+## Publish Workflow (`.github/workflows/publish.yml`)
+
+Triggers on `v*` tag pushes. Publishes the package to pub.dev:
 
 ```bash
 git tag v0.1.0

--- a/docs/github-setup.md
+++ b/docs/github-setup.md
@@ -17,6 +17,8 @@ gh label create "status: in progress"  --color fbca04 --description "Actively be
 gh label create "priority: high"     --color b60205 --description "Urgent"                        --repo rania-run/fro
 gh label create "good first issue"   --color 7057ff --description "Good for newcomers"            --repo rania-run/fro --force
 gh label create "breaking change"    --color ee0701 --description "Breaks existing behaviour"     --repo rania-run/fro
+gh label create "type: testing"      --color c5def5 --description "Test coverage or test infrastructure" --repo rania-run/fro
+gh label create "chore: deps"        --color 0e8a16 --description "Dependency updates"               --repo rania-run/fro
 ```
 
 ---
@@ -79,6 +81,19 @@ Defined in `.github/workflows/ci.yml`. Runs on push/PR to `main`:
 2. `dart analyze --fatal-infos`
 3. `dart format --set-exit-if-changed .`
 4. `dart test`
+
+---
+
+## Auto Assign (`.github/workflows/auto-assign.yml`)
+
+Runs on every new issue or PR:
+
+| Event | Assignee |
+|---|---|
+| Issue (default) | `rania-run` |
+| Issue labeled `type: testing` or `chore: deps` | `copilot` |
+| PR opened | PR author |
+| PR opened | Earliest open milestone is set automatically |
 
 ---
 

--- a/docs/github-setup.md
+++ b/docs/github-setup.md
@@ -90,8 +90,7 @@ Runs on every new issue or PR:
 
 | Event | Assignee |
 |---|---|
-| Issue (default) | `rania-run` |
-| Issue labeled `type: testing` or `chore: deps` | `copilot` |
+| Issue opened | `rania-run` |
 | PR opened | PR author |
 | PR opened | Earliest open milestone is set automatically |
 

--- a/docs/github-setup.md
+++ b/docs/github-setup.md
@@ -92,7 +92,7 @@ Runs on every new issue or PR:
 |---|---|
 | Issue opened | `rania-run` |
 | PR opened | PR author |
-| PR opened | Earliest open milestone is set automatically |
+| PR opened (milestone auto-set) | Earliest open milestone is set automatically |
 
 ---
 

--- a/lib/commands/bump_command.dart
+++ b/lib/commands/bump_command.dart
@@ -67,8 +67,6 @@ class BumpCommand extends Command<void> {
       negatable: false,
     );
 
-  static final _envPattern = RegExp(r'^[a-zA-Z][\w-]*$');
-
   @override
   Future<void> run() async {
     final env = argResults!['env'] as String;
@@ -76,7 +74,7 @@ class BumpCommand extends Command<void> {
     final ci = argResults!['ci'] as bool;
     final noPush = argResults!['no-push'] as bool;
 
-    if (!_envPattern.hasMatch(env)) {
+    if (!GitService.envPattern.hasMatch(env)) {
       stderr.writeln(chalk.red(
         'Invalid --env "$env": must start with a letter and contain only letters, digits, underscores, or hyphens.',
       ));

--- a/lib/commands/bump_command.dart
+++ b/lib/commands/bump_command.dart
@@ -67,12 +67,22 @@ class BumpCommand extends Command<void> {
       negatable: false,
     );
 
+  static final _envPattern = RegExp(r'^[a-zA-Z][\w-]*$');
+
   @override
   Future<void> run() async {
     final env = argResults!['env'] as String;
     final strategy = BumpStrategy.parse(argResults!['strategy'] as String);
     final ci = argResults!['ci'] as bool;
     final noPush = argResults!['no-push'] as bool;
+
+    if (!_envPattern.hasMatch(env)) {
+      stderr.writeln(chalk.red(
+        'Invalid --env "$env": must start with a letter and contain only letters, digits, underscores, or hyphens.',
+      ));
+      exitCode = 1;
+      return;
+    }
 
     try {
       final current = _versions.readVersion();

--- a/lib/commands/bump_command.dart
+++ b/lib/commands/bump_command.dart
@@ -99,6 +99,9 @@ class BumpCommand extends Command<void> {
         await _git.pushTag(tag);
         stdout.writeln(chalk.green('✓ tag pushed to origin'));
       }
+    } on FileSystemException catch (e) {
+      stderr.writeln(chalk.red('File error: ${e.message} — ${e.path}'));
+      exitCode = 1;
     } on ArgumentError catch (e) {
       stderr.writeln(chalk.red('Error: $e'));
       exitCode = 1;

--- a/lib/commands/bump_command.dart
+++ b/lib/commands/bump_command.dart
@@ -1,0 +1,134 @@
+import 'dart:io';
+
+import 'package:args/args.dart';
+import 'package:args/command_runner.dart';
+import 'package:chalkdart/chalkdart.dart';
+import 'package:fro/models/bump_strategy.dart';
+import 'package:fro/services/git_service.dart';
+import 'package:fro/services/version_service.dart';
+
+/// `fro bump` — bumps the app version and creates a git tag.
+///
+/// Reads the current version from pubspec.yaml, increments the requested
+/// semver component, increments the build number based on the latest git
+/// tag for the environment, writes the new version back to pubspec.yaml,
+/// and creates a git tag in the format `env-vMAJOR.MINOR.PATCH+BUILD`.
+///
+/// Usage:
+///   fro bump --env=prod --strategy=patch
+///   fro bump --env=stg  --strategy=minor
+///   fro bump --env=prod --strategy=patch --ci   # skip confirmation
+class BumpCommand extends Command<void> {
+  BumpCommand({
+    VersionService? versionService,
+    GitService? gitService,
+  })  : _versions =
+            versionService ?? const VersionService(pubspecPath: 'pubspec.yaml'),
+        _git = gitService ?? const GitService();
+
+  @override
+  final String name = 'bump';
+
+  @override
+  final String description = 'Bump the app version and create a git tag.';
+
+  final VersionService _versions;
+  final GitService _git;
+
+  @override
+  ArgParser get argParser => ArgParser()
+    ..addOption(
+      'env',
+      abbr: 'e',
+      help: 'Target environment.',
+      valueHelp: 'prod|stg|dev',
+      mandatory: true,
+    )
+    ..addOption(
+      'strategy',
+      abbr: 's',
+      help: 'Which semver component to bump.',
+      allowed: ['major', 'minor', 'patch'],
+      allowedHelp: {
+        'major': 'Breaking change: 1.0.0 → 2.0.0',
+        'minor': 'New feature:     1.0.0 → 1.1.0',
+        'patch': 'Bug fix:         1.0.0 → 1.0.1',
+      },
+      defaultsTo: 'patch',
+    )
+    ..addFlag(
+      'ci',
+      help: 'Skip confirmation prompts (for CI pipelines).',
+      negatable: false,
+    )
+    ..addFlag(
+      'no-push',
+      help: 'Create the git tag locally without pushing to origin.',
+      negatable: false,
+    );
+
+  @override
+  Future<void> run() async {
+    final env = argResults!['env'] as String;
+    final strategy = BumpStrategy.parse(argResults!['strategy'] as String);
+    final ci = argResults!['ci'] as bool;
+    final noPush = argResults!['no-push'] as bool;
+
+    try {
+      final current = _versions.readVersion();
+      final latestTag = await _git.latestTagForEnv(env);
+      final latestBuild = latestTag?.build ?? current.build;
+      final next = current.bump(strategy, newBuild: latestBuild + 1);
+      final tag = '$env-v$next';
+
+      _printPlan(
+          env: env, current: current, next: next, tag: tag, noPush: noPush);
+
+      if (!ci && !_confirm()) {
+        stdout.writeln(chalk.yellow('Aborted.'));
+        return;
+      }
+
+      _versions.writeVersion(next);
+      stdout.writeln(chalk.green('✓ pubspec.yaml updated to $next'));
+
+      await _git.createTag(tag);
+      stdout.writeln(chalk.green('✓ git tag $tag created'));
+
+      if (!noPush) {
+        await _git.pushTag(tag);
+        stdout.writeln(chalk.green('✓ tag pushed to origin'));
+      }
+    } on ArgumentError catch (e) {
+      stderr.writeln(chalk.red('Error: $e'));
+      exitCode = 1;
+    } on FormatException catch (e) {
+      stderr.writeln(chalk.red('Error: ${e.message}'));
+      exitCode = 1;
+    } on GitException catch (e) {
+      stderr.writeln(chalk.red('Git error: ${e.message}'));
+      exitCode = 1;
+    }
+  }
+
+  void _printPlan({
+    required String env,
+    required Object current,
+    required Object next,
+    required String tag,
+    required bool noPush,
+  }) {
+    stdout.writeln('');
+    stdout.writeln('  ${chalk.bold('current:')} $current');
+    stdout.writeln('  ${chalk.bold('next:')}    $next');
+    stdout.writeln('  ${chalk.bold('tag:')}     $tag');
+    if (noPush) stdout.writeln('  ${chalk.yellow('(tag will not be pushed)')}');
+    stdout.writeln('');
+  }
+
+  bool _confirm() {
+    stdout.write('Apply? [y/N] ');
+    final input = stdin.readLineSync()?.trim().toLowerCase();
+    return input == 'y' || input == 'yes';
+  }
+}

--- a/lib/commands/check_command.dart
+++ b/lib/commands/check_command.dart
@@ -1,30 +1,75 @@
 import 'dart:io';
 
+import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:chalkdart/chalkdart.dart';
+import 'package:fro/services/git_service.dart';
 import 'package:fro/services/version_service.dart';
 
-/// `fro check` — prints the current version from `pubspec.yaml`.
+/// `fro check` — shows the current app version.
+///
+/// Without flags: reads from pubspec.yaml.
+/// With --env: also shows the latest git tag for that environment and
+/// whether pubspec is in sync.
 ///
 /// Usage:
 ///   fro check
+///   fro check --env=prod
 class CheckCommand extends Command<void> {
+  CheckCommand({
+    VersionService? versionService,
+    GitService? gitService,
+  })  : _versions =
+            versionService ?? const VersionService(pubspecPath: 'pubspec.yaml'),
+        _git = gitService ?? const GitService();
+
   @override
   final String name = 'check';
 
   @override
-  final String description = 'Show the current app version from pubspec.yaml.';
+  final String description = 'Show the current app version.';
+
+  final VersionService _versions;
+  final GitService _git;
+
+  @override
+  ArgParser get argParser => ArgParser()
+    ..addOption(
+      'env',
+      abbr: 'e',
+      help:
+          'Compare pubspec version against the latest git tag for this environment.',
+      valueHelp: 'prod|stg|dev',
+    );
 
   @override
   Future<void> run() async {
-    final pubspecPath = argResults?.rest.firstOrNull ?? 'pubspec.yaml';
-    final service = VersionService(pubspecPath: pubspecPath);
+    final env = argResults?['env'] as String?;
 
     try {
-      final version = service.readVersion();
-      stdout.writeln('${chalk.bold('Version:')} $version');
+      final pubspecVersion = _versions.readVersion();
+      stdout.writeln('${chalk.bold('pubspec:')} $pubspecVersion');
+
+      if (env != null) {
+        final tagVersion = await _git.latestTagForEnv(env);
+
+        if (tagVersion == null) {
+          stdout.writeln(
+              '${chalk.bold('git/$env:')} ${chalk.yellow('no tags found')}');
+        } else {
+          final inSync = pubspecVersion.toString() == tagVersion.toString();
+          final status = inSync
+              ? chalk.green('✓ in sync')
+              : chalk.yellow('✗ not tagged yet');
+          stdout.writeln('${chalk.bold('git/$env:')} $tagVersion  $status');
+        }
+      }
     } on FormatException catch (e) {
       stderr.writeln(chalk.red('Error: ${e.message}'));
+      exitCode = 1;
+    } on GitException catch (e) {
+      stderr.writeln(chalk.red('Git error: ${e.message}'));
+      exitCode = 1;
     }
   }
 }

--- a/lib/commands/check_command.dart
+++ b/lib/commands/check_command.dart
@@ -42,9 +42,19 @@ class CheckCommand extends Command<void> {
       valueHelp: 'prod|stg|dev',
     );
 
+  static final _envPattern = RegExp(r'^[a-zA-Z][\w-]*$');
+
   @override
   Future<void> run() async {
     final env = argResults?['env'] as String?;
+
+    if (env != null && !_envPattern.hasMatch(env)) {
+      stderr.writeln(chalk.red(
+        'Invalid --env "$env": must start with a letter and contain only letters, digits, underscores, or hyphens.',
+      ));
+      exitCode = 1;
+      return;
+    }
 
     try {
       final pubspecVersion = _versions.readVersion();

--- a/lib/commands/check_command.dart
+++ b/lib/commands/check_command.dart
@@ -64,6 +64,9 @@ class CheckCommand extends Command<void> {
           stdout.writeln('${chalk.bold('git/$env:')} $tagVersion  $status');
         }
       }
+    } on FileSystemException catch (e) {
+      stderr.writeln(chalk.red('File error: ${e.message} — ${e.path}'));
+      exitCode = 1;
     } on FormatException catch (e) {
       stderr.writeln(chalk.red('Error: ${e.message}'));
       exitCode = 1;

--- a/lib/commands/check_command.dart
+++ b/lib/commands/check_command.dart
@@ -42,13 +42,11 @@ class CheckCommand extends Command<void> {
       valueHelp: 'prod|stg|dev',
     );
 
-  static final _envPattern = RegExp(r'^[a-zA-Z][\w-]*$');
-
   @override
   Future<void> run() async {
     final env = argResults?['env'] as String?;
 
-    if (env != null && !_envPattern.hasMatch(env)) {
+    if (env != null && !GitService.envPattern.hasMatch(env)) {
       stderr.writeln(chalk.red(
         'Invalid --env "$env": must start with a letter and contain only letters, digits, underscores, or hyphens.',
       ));

--- a/lib/models/app_version.dart
+++ b/lib/models/app_version.dart
@@ -1,3 +1,5 @@
+import 'package:fro/models/bump_strategy.dart';
+
 /// Represents a parsed Flutter app version.
 ///
 /// Versions follow semver with a build number: `1.2.3+45`.
@@ -32,6 +34,28 @@ class AppVersion {
       patch: int.parse(match.namedGroup('patch')!),
       build: int.parse(match.namedGroup('build')!),
     );
+  }
+
+  /// Returns a new version with the [strategy] component incremented and [newBuild] applied.
+  ///
+  /// Minor bumps reset patch to 0. Major bumps reset both minor and patch.
+  AppVersion bump(BumpStrategy strategy, {required int newBuild}) {
+    return switch (strategy) {
+      BumpStrategy.major =>
+        AppVersion(major: major + 1, minor: 0, patch: 0, build: newBuild),
+      BumpStrategy.minor =>
+        AppVersion(major: major, minor: minor + 1, patch: 0, build: newBuild),
+      BumpStrategy.patch => AppVersion(
+          major: major, minor: minor, patch: patch + 1, build: newBuild),
+    };
+  }
+
+  /// Returns true if this version is strictly newer than [other].
+  bool isNewerThan(AppVersion other) {
+    if (major != other.major) return major > other.major;
+    if (minor != other.minor) return minor > other.minor;
+    if (patch != other.patch) return patch > other.patch;
+    return build > other.build;
   }
 
   @override

--- a/lib/models/bump_strategy.dart
+++ b/lib/models/bump_strategy.dart
@@ -1,0 +1,20 @@
+/// The semver component to increment on a version bump.
+enum BumpStrategy {
+  major,
+  minor,
+  patch;
+
+  /// Parses [value] (case-insensitive) into a [BumpStrategy].
+  ///
+  /// Throws [ArgumentError] for unknown values.
+  static BumpStrategy parse(String value) {
+    return switch (value.toLowerCase()) {
+      'major' => BumpStrategy.major,
+      'minor' => BumpStrategy.minor,
+      'patch' => BumpStrategy.patch,
+      _ => throw ArgumentError(
+          'Unknown strategy: "$value". Expected major, minor, or patch.',
+        ),
+    };
+  }
+}

--- a/lib/services/git_service.dart
+++ b/lib/services/git_service.dart
@@ -1,0 +1,126 @@
+import 'dart:io';
+
+import 'package:fro/models/app_version.dart';
+
+/// Signature for running a process — injectable for testing.
+typedef ProcessRunner = Future<ProcessResult> Function(
+  String executable,
+  List<String> arguments,
+);
+
+Future<ProcessResult> _defaultRunner(
+  String executable,
+  List<String> arguments,
+) =>
+    Process.run(executable, arguments);
+
+/// Runs git commands and parses environment version tags.
+///
+/// Tag format: `env-vMAJOR.MINOR.PATCH+BUILD` (e.g. `prod-v1.2.3+45`).
+class GitService {
+  const GitService({ProcessRunner runner = _defaultRunner}) : _run = runner;
+
+  final ProcessRunner _run;
+
+  static final _tagPattern = RegExp(
+    r'^(?<env>[a-zA-Z]\w*)-v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)\+(?<build>\d+)$',
+  );
+
+  /// Returns all git tags in the repository.
+  ///
+  /// Throws [GitException] if the git command fails.
+  Future<List<String>> tags() async {
+    final result =
+        await _run('git', ['tag', '--list', '--sort=-version:refname']);
+    _assertSuccess(result, 'git tag');
+    final output = (result.stdout as String).trim();
+    if (output.isEmpty) return [];
+    return output
+        .split('\n')
+        .map((t) => t.trim())
+        .where((t) => t.isNotEmpty)
+        .toList();
+  }
+
+  /// Returns the latest version for [env] parsed from git tags, or null if none exist.
+  Future<AppVersion?> latestTagForEnv(String env) async {
+    final allTags = await tags();
+    final versions = allTags
+        .where((t) =>
+            _tagPattern.hasMatch(t) &&
+            _tagPattern.firstMatch(t)!.namedGroup('env') == env)
+        .map(_parseTagVersion)
+        .whereType<AppVersion>()
+        .toList();
+
+    if (versions.isEmpty) return null;
+    return versions.reduce((a, b) => a.isNewerThan(b) ? a : b);
+  }
+
+  /// Returns the latest version tag for every environment found in git tags.
+  Future<Map<String, AppVersion>> latestTagsPerEnv() async {
+    final allTags = await tags();
+    final result = <String, AppVersion>{};
+
+    for (final tag in allTags) {
+      final match = _tagPattern.firstMatch(tag);
+      if (match == null) continue;
+      final env = match.namedGroup('env')!;
+      final version = _parseTagVersion(tag);
+      if (version == null) continue;
+      final existing = result[env];
+      if (existing == null || version.isNewerThan(existing)) {
+        result[env] = version;
+      }
+    }
+
+    return result;
+  }
+
+  /// Creates a local git tag [tag].
+  ///
+  /// Throws [GitException] if the tag already exists or the command fails.
+  Future<void> createTag(String tag) async {
+    final result = await _run('git', ['tag', tag]);
+    _assertSuccess(result, 'git tag $tag');
+  }
+
+  /// Pushes tag [tag] to origin.
+  Future<void> pushTag(String tag) async {
+    final result = await _run('git', ['push', 'origin', tag]);
+    _assertSuccess(result, 'git push origin $tag');
+  }
+
+  /// Returns the current branch name.
+  Future<String> currentBranch() async {
+    final result = await _run('git', ['rev-parse', '--abbrev-ref', 'HEAD']);
+    _assertSuccess(result, 'git rev-parse');
+    return (result.stdout as String).trim();
+  }
+
+  void _assertSuccess(ProcessResult result, String command) {
+    if (result.exitCode != 0) {
+      throw GitException('`$command` failed: ${result.stderr}');
+    }
+  }
+
+  AppVersion? _parseTagVersion(String tag) {
+    final match = _tagPattern.firstMatch(tag);
+    if (match == null) return null;
+    return AppVersion(
+      major: int.parse(match.namedGroup('major')!),
+      minor: int.parse(match.namedGroup('minor')!),
+      patch: int.parse(match.namedGroup('patch')!),
+      build: int.parse(match.namedGroup('build')!),
+    );
+  }
+}
+
+/// Thrown when a git command exits with a non-zero code.
+class GitException implements Exception {
+  const GitException(this.message);
+  final String message;
+
+  @override
+  String toString() => 'GitException: $message';
+}

--- a/lib/services/git_service.dart
+++ b/lib/services/git_service.dart
@@ -23,7 +23,7 @@ class GitService {
   final ProcessRunner _run;
 
   static final _tagPattern = RegExp(
-    r'^(?<env>[a-zA-Z]\w*)-v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)\+(?<build>\d+)$',
+    r'^(?<env>[a-zA-Z][\w-]*?)-v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)\+(?<build>\d+)$',
   );
 
   /// Returns all git tags in the repository.

--- a/lib/services/git_service.dart
+++ b/lib/services/git_service.dart
@@ -26,6 +26,9 @@ class GitService {
     r'^(?<env>[a-zA-Z][\w-]*?)-v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)\+(?<build>\d+)$',
   );
 
+  /// Pattern that a valid environment name must match.
+  static final envPattern = RegExp(r'^[a-zA-Z][\w-]*$');
+
   /// Returns all git tags in the repository.
   ///
   /// Throws [GitException] if the git command fails.
@@ -46,9 +49,10 @@ class GitService {
   Future<AppVersion?> latestTagForEnv(String env) async {
     final allTags = await tags();
     final versions = allTags
-        .where((t) =>
-            _tagPattern.hasMatch(t) &&
-            _tagPattern.firstMatch(t)!.namedGroup('env') == env)
+        .where((t) {
+          final m = _tagPattern.firstMatch(t);
+          return m != null && m.namedGroup('env') == env;
+        })
         .map(_parseTagVersion)
         .whereType<AppVersion>()
         .toList();

--- a/test/app_version_test.dart
+++ b/test/app_version_test.dart
@@ -44,6 +44,19 @@ void main() {
     });
   });
 
+  group('BumpStrategy.parse', () {
+    test('parses all valid strategies case-insensitively', () {
+      expect(BumpStrategy.parse('patch'), BumpStrategy.patch);
+      expect(BumpStrategy.parse('MINOR'), BumpStrategy.minor);
+      expect(BumpStrategy.parse('Major'), BumpStrategy.major);
+    });
+
+    test('throws ArgumentError for unknown value', () {
+      expect(() => BumpStrategy.parse('hotfix'), throwsArgumentError);
+      expect(() => BumpStrategy.parse(''), throwsArgumentError);
+    });
+  });
+
   group('AppVersion.isNewerThan', () {
     test('higher major is newer', () {
       expect(
@@ -54,6 +67,12 @@ void main() {
     test('higher minor is newer when major is equal', () {
       expect(
           AppVersion.parse('1.2.0+1').isNewerThan(AppVersion.parse('1.1.9+99')),
+          isTrue);
+    });
+
+    test('higher patch is newer when major and minor are equal', () {
+      expect(
+          AppVersion.parse('1.0.1+1').isNewerThan(AppVersion.parse('1.0.0+99')),
           isTrue);
     });
 

--- a/test/app_version_test.dart
+++ b/test/app_version_test.dart
@@ -1,4 +1,5 @@
 import 'package:fro/models/app_version.dart';
+import 'package:fro/models/bump_strategy.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -20,6 +21,52 @@ void main() {
       expect(() => AppVersion.parse('1.2.3'), throwsFormatException);
       expect(() => AppVersion.parse('bad'), throwsFormatException);
       expect(() => AppVersion.parse(''), throwsFormatException);
+    });
+  });
+
+  group('AppVersion.bump', () {
+    final base = AppVersion.parse('1.2.3+10');
+
+    test('patch increments patch and build', () {
+      final v = base.bump(BumpStrategy.patch, newBuild: 11);
+      expect(v.toString(), '1.2.4+11');
+    });
+
+    test('minor increments minor, resets patch, increments build', () {
+      final v = base.bump(BumpStrategy.minor, newBuild: 11);
+      expect(v.toString(), '1.3.0+11');
+    });
+
+    test('major increments major, resets minor and patch, increments build',
+        () {
+      final v = base.bump(BumpStrategy.major, newBuild: 11);
+      expect(v.toString(), '2.0.0+11');
+    });
+  });
+
+  group('AppVersion.isNewerThan', () {
+    test('higher major is newer', () {
+      expect(
+          AppVersion.parse('2.0.0+1').isNewerThan(AppVersion.parse('1.9.9+99')),
+          isTrue);
+    });
+
+    test('higher minor is newer when major is equal', () {
+      expect(
+          AppVersion.parse('1.2.0+1').isNewerThan(AppVersion.parse('1.1.9+99')),
+          isTrue);
+    });
+
+    test('higher build is newer when semver is equal', () {
+      expect(
+          AppVersion.parse('1.0.0+5').isNewerThan(AppVersion.parse('1.0.0+4')),
+          isTrue);
+    });
+
+    test('same version is not newer', () {
+      expect(
+          AppVersion.parse('1.0.0+1').isNewerThan(AppVersion.parse('1.0.0+1')),
+          isFalse);
     });
   });
 }

--- a/test/bump_command_test.dart
+++ b/test/bump_command_test.dart
@@ -1,0 +1,52 @@
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:fro/commands/bump_command.dart';
+import 'package:fro/models/app_version.dart';
+import 'package:fro/services/git_service.dart';
+import 'package:fro/services/version_service.dart';
+import 'package:test/test.dart';
+
+class _FakeVersionService extends VersionService {
+  _FakeVersionService() : super(pubspecPath: '');
+
+  @override
+  AppVersion readVersion() => AppVersion.parse('1.0.0+1');
+
+  @override
+  void writeVersion(AppVersion v) {}
+}
+
+CommandRunner<void> _runner() => CommandRunner<void>('fro', '')
+  ..addCommand(BumpCommand(
+    versionService: _FakeVersionService(),
+    gitService: GitService(
+      runner: (_, __) async => ProcessResult(0, 0, '', ''),
+    ),
+  ));
+
+void main() {
+  group('BumpCommand --env validation', () {
+    setUp(() => exitCode = 0);
+
+    test('rejects env starting with a digit', () async {
+      await _runner().run(['bump', '--env=1prod', '--ci']);
+      expect(exitCode, 1);
+    });
+
+    test('rejects env with invalid characters', () async {
+      await _runner().run(['bump', '--env=prod.us', '--ci']);
+      expect(exitCode, 1);
+    });
+
+    test('accepts simple env', () async {
+      await _runner().run(['bump', '--env=prod', '--ci', '--no-push']);
+      expect(exitCode, 0);
+    });
+
+    test('accepts hyphenated env', () async {
+      await _runner().run(['bump', '--env=prod-us', '--ci', '--no-push']);
+      expect(exitCode, 0);
+    });
+  });
+}

--- a/test/check_command_test.dart
+++ b/test/check_command_test.dart
@@ -1,0 +1,73 @@
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:fro/commands/check_command.dart';
+import 'package:fro/models/app_version.dart';
+import 'package:fro/services/git_service.dart';
+import 'package:fro/services/version_service.dart';
+import 'package:test/test.dart';
+
+class _FakeVersionService extends VersionService {
+  _FakeVersionService() : super(pubspecPath: '');
+
+  @override
+  AppVersion readVersion() => AppVersion.parse('1.0.0+1');
+}
+
+CommandRunner<void> _runner({String gitOutput = ''}) =>
+    CommandRunner<void>('fro', '')
+      ..addCommand(CheckCommand(
+        versionService: _FakeVersionService(),
+        gitService: GitService(
+          runner: (_, __) async => ProcessResult(0, 0, gitOutput, ''),
+        ),
+      ));
+
+void main() {
+  group('CheckCommand --env validation', () {
+    setUp(() => exitCode = 0);
+
+    test('rejects env starting with a digit', () async {
+      await _runner().run(['check', '--env=1prod']);
+      expect(exitCode, 1);
+    });
+
+    test('rejects env with dots', () async {
+      await _runner().run(['check', '--env=prod.us']);
+      expect(exitCode, 1);
+    });
+
+    test('accepts simple env', () async {
+      await _runner().run(['check', '--env=prod']);
+      expect(exitCode, 0);
+    });
+
+    test('accepts hyphenated env', () async {
+      await _runner().run(['check', '--env=prod-us']);
+      expect(exitCode, 0);
+    });
+  });
+
+  group('CheckCommand without --env', () {
+    setUp(() => exitCode = 0);
+
+    test('exits successfully', () async {
+      await _runner().run(['check']);
+      expect(exitCode, 0);
+    });
+  });
+
+  group('CheckCommand with --env and tags', () {
+    setUp(() => exitCode = 0);
+
+    test('exits successfully when env has no tags', () async {
+      await _runner(gitOutput: '').run(['check', '--env=prod']);
+      expect(exitCode, 0);
+    });
+
+    test('exits successfully when env has a matching tag', () async {
+      await _runner(gitOutput: 'prod-v1.0.0+1\n').run(['check', '--env=prod']);
+      expect(exitCode, 0);
+    });
+  });
+}

--- a/test/git_service_test.dart
+++ b/test/git_service_test.dart
@@ -54,6 +54,22 @@ void main() {
       final version = await svc.latestTagForEnv('prod');
       expect(version.toString(), '1.0.0+1');
     });
+
+    test('parses hyphenated env name correctly', () async {
+      final svc = GitService(
+        runner: _fakeRunner('prod-us-v1.0.0+1\nprod-v2.0.0+2\n'),
+      );
+      final version = await svc.latestTagForEnv('prod-us');
+      expect(version.toString(), '1.0.0+1');
+    });
+
+    test('does not conflate prod with prod-us', () async {
+      final svc = GitService(
+        runner: _fakeRunner('prod-us-v1.0.0+1\nprod-v2.0.0+2\n'),
+      );
+      final version = await svc.latestTagForEnv('prod');
+      expect(version.toString(), '2.0.0+2');
+    });
   });
 
   group('GitService.latestTagsPerEnv', () {

--- a/test/git_service_test.dart
+++ b/test/git_service_test.dart
@@ -1,0 +1,89 @@
+import 'dart:io';
+
+import 'package:fro/services/git_service.dart';
+import 'package:test/test.dart';
+
+/// Builds a fake [ProcessRunner] that returns [stdout] with exit code 0.
+ProcessRunner _fakeRunner(String stdout) {
+  return (executable, args) async => ProcessResult(0, 0, stdout, '');
+}
+
+/// Builds a fake [ProcessRunner] that fails with [stderr].
+ProcessRunner _failingRunner(String stderr) {
+  return (executable, args) async => ProcessResult(0, 1, '', stderr);
+}
+
+void main() {
+  group('GitService.tags', () {
+    test('returns parsed list of tags', () async {
+      final svc =
+          GitService(runner: _fakeRunner('prod-v1.0.0+1\nstg-v1.0.0+2\n'));
+      expect(await svc.tags(), ['prod-v1.0.0+1', 'stg-v1.0.0+2']);
+    });
+
+    test('returns empty list when no tags exist', () async {
+      final svc = GitService(runner: _fakeRunner(''));
+      expect(await svc.tags(), isEmpty);
+    });
+
+    test('throws GitException when git command fails', () async {
+      final svc = GitService(runner: _failingRunner('not a git repo'));
+      expect(svc.tags(), throwsA(isA<GitException>()));
+    });
+  });
+
+  group('GitService.latestTagForEnv', () {
+    test('returns latest version for the requested env', () async {
+      final svc = GitService(
+        runner: _fakeRunner(
+          'prod-v1.0.0+1\nprod-v1.2.0+5\nprod-v1.1.0+3\nstg-v2.0.0+10\n',
+        ),
+      );
+      final version = await svc.latestTagForEnv('prod');
+      expect(version.toString(), '1.2.0+5');
+    });
+
+    test('returns null when no tags exist for the env', () async {
+      final svc = GitService(runner: _fakeRunner('stg-v1.0.0+1\n'));
+      expect(await svc.latestTagForEnv('prod'), isNull);
+    });
+
+    test('ignores tags from other environments', () async {
+      final svc =
+          GitService(runner: _fakeRunner('stg-v9.9.9+99\nprod-v1.0.0+1\n'));
+      final version = await svc.latestTagForEnv('prod');
+      expect(version.toString(), '1.0.0+1');
+    });
+  });
+
+  group('GitService.latestTagsPerEnv', () {
+    test('returns latest version per environment', () async {
+      final svc = GitService(
+        runner: _fakeRunner('prod-v1.2.0+5\nstg-v1.3.0+8\ndev-v0.1.0+2\n'),
+      );
+      final map = await svc.latestTagsPerEnv();
+      expect(map['prod'].toString(), '1.2.0+5');
+      expect(map['stg'].toString(), '1.3.0+8');
+      expect(map['dev'].toString(), '0.1.0+2');
+    });
+
+    test('returns empty map when no tags exist', () async {
+      final svc = GitService(runner: _fakeRunner(''));
+      expect(await svc.latestTagsPerEnv(), isEmpty);
+    });
+  });
+
+  group('GitService.currentBranch', () {
+    test('returns trimmed branch name', () async {
+      final svc = GitService(runner: _fakeRunner('feature/my-branch\n'));
+      expect(await svc.currentBranch(), 'feature/my-branch');
+    });
+  });
+
+  group('GitService.createTag', () {
+    test('throws GitException when tag already exists', () async {
+      final svc = GitService(runner: _failingRunner('tag already exists'));
+      expect(svc.createTag('prod-v1.0.0+1'), throwsA(isA<GitException>()));
+    });
+  });
+}

--- a/test/git_service_test.dart
+++ b/test/git_service_test.dart
@@ -62,9 +62,9 @@ void main() {
         runner: _fakeRunner('prod-v1.2.0+5\nstg-v1.3.0+8\ndev-v0.1.0+2\n'),
       );
       final map = await svc.latestTagsPerEnv();
-      expect(map['prod'].toString(), '1.2.0+5');
-      expect(map['stg'].toString(), '1.3.0+8');
-      expect(map['dev'].toString(), '0.1.0+2');
+      expect(map['prod']!.toString(), '1.2.0+5');
+      expect(map['stg']!.toString(), '1.3.0+8');
+      expect(map['dev']!.toString(), '0.1.0+2');
     });
 
     test('returns empty map when no tags exist', () async {
@@ -84,6 +84,31 @@ void main() {
     test('throws GitException when tag already exists', () async {
       final svc = GitService(runner: _failingRunner('tag already exists'));
       expect(svc.createTag('prod-v1.0.0+1'), throwsA(isA<GitException>()));
+    });
+  });
+
+  group('GitService.pushTag', () {
+    test('throws GitException when push fails', () async {
+      final svc = GitService(runner: _failingRunner('failed to push tag'));
+      expect(svc.pushTag('prod-v1.0.0+1'), throwsA(isA<GitException>()));
+    });
+
+    test('calls git push with correct arguments', () async {
+      String? capturedExecutable;
+      List<String>? capturedArgs;
+
+      final svc = GitService(
+        runner: (executable, args) async {
+          capturedExecutable = executable;
+          capturedArgs = args;
+          return ProcessResult(0, 0, '', '');
+        },
+      );
+
+      await svc.pushTag('prod-v1.0.0+1');
+
+      expect(capturedExecutable, 'git');
+      expect(capturedArgs, ['push', 'origin', 'prod-v1.0.0+1']);
     });
   });
 }


### PR DESCRIPTION
## What does this PR do?

Implements the core CLI commands (`fro check` and `fro bump`), along with repo automation and a fix for hyphenated environment names in tag parsing.

## Related issue
Closes #1

## Changes

### Core implementation
- **`AppVersion`** — added `bump(strategy, newBuild)` and `isNewerThan()` methods
- **`BumpStrategy`** — new enum with `parse()` (major / minor / patch)
- **`GitService`** — reads/creates/pushes git tags; injectable `ProcessRunner` for testability; env capture regex updated to support hyphenated names (e.g. `prod-us`)
- **`fro check`** — prints pubspec version; `--env` flag adds git tag comparison
- **`fro bump`** — bumps version + creates tag; supports `--ci` and `--no-push` flags

### Repo automation & config
- **`auto-assign.yml`** — auto-assigns all issues/PRs to `rania-run`
- **`labeler.yml`** — auto-labels PRs based on changed paths
- **`dependabot.yml`** — weekly Dart pub dependency updates
- **`CODEOWNERS`** — `rania-run` owns all files
- **`pull_request_template.md`** — standard PR checklist template
- **`docs/github-setup.md`** — documents the automation setup

## How to test

```bash
dart pub global activate --source path .
cd /path/to/any/flutter/app
fro check
fro check --env=prod
fro bump --env=prod --strategy=patch
fro bump --env=prod-us --strategy=patch   # hyphenated env
```

## Checklist
- [x] `dart analyze --fatal-infos` passes
- [x] `dart format --set-exit-if-changed .` passes
- [x] Tests added / updated for every new behaviour (27 tests total)
- [x] No debug code or commented-out blocks left in