### PR TITLE
feat: add example/ project for manual testing and pub.dev showcase

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ local/
 # Secrets
 .env
 *.env
+
+# Example project — setup.sh creates a nested git repo for demo purposes;
+# ignore it so the parent repo keeps tracking example/ as regular files.
+example/.git/

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="$PROJECT_DIR$" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/example" vcs="Git" />
   </component>
 </project>

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,127 @@
+# fro — Example Project
+
+A minimal `pubspec.yaml` for smoke-testing the [`fro`](https://pub.dev/packages/fro) CLI. `fro` only reads the pubspec version and git tags — no Flutter project structure needed.
+
+## Prerequisites
+
+```bash
+dart pub global activate fro
+```
+
+## First-time setup
+
+Run these commands once after cloning. They initialise a local git repo and seed two historical release tags:
+
+```bash
+cd example
+git init -b main && git add . && git commit -m "chore: initial example project"
+git tag prod-v0.9.0+3
+git tag prod-us-v0.8.0+2
+```
+
+What the tags represent:
+- `prod-v0.9.0+3` — a past prod release (older than the current pubspec version)
+- `prod-us-v0.8.0+2` — a past prod-us release
+
+---
+
+## Walkthrough
+
+### Step 1 — Check current version
+
+```bash
+fro check
+```
+
+Expected output:
+
+```
+pubspec: 1.0.0+1
+```
+
+---
+
+### Step 2 — Check prod environment
+
+```bash
+fro check --env=prod
+```
+
+Expected output:
+
+```
+pubspec:   1.0.0+1
+git/prod:  0.9.0+3  ✗ not tagged yet
+```
+
+The pubspec version `1.0.0+1` has not been tagged for `prod`, so `fro` reports it as unreleased.
+
+---
+
+### Step 3 — Bump prod (patch)
+
+```bash
+fro bump --env=prod --strategy=patch --no-push
+```
+
+- Increments the patch version: `1.0.0` → `1.0.1`
+- Takes the next build number after the latest `prod` tag (`prod-v0.9.0+3` → build 3): `3+1 = 4`
+- Updates `pubspec.yaml` to `1.0.1+4`
+- Creates git tag `prod-v1.0.1+4`
+
+Expected output:
+
+```
+  current: 1.0.0+1
+  next:    1.0.1+4
+  tag:     prod-v1.0.1+4
+  (tag will not be pushed)
+
+Apply? [y/N] ✓ pubspec.yaml updated to 1.0.1+4
+✓ git tag prod-v1.0.1+4 created
+```
+
+---
+
+### Step 4 — Bump prod-us (patch)
+
+```bash
+fro bump --env=prod-us --strategy=patch --no-push
+```
+
+- Increments the patch version: `1.0.1` → `1.0.2`
+- Takes the next build number after the latest `prod-us` tag (`prod-us-v0.8.0+2` → build 2): `2+1 = 3`
+- Updates `pubspec.yaml` to `1.0.2+3`
+- Creates git tag `prod-us-v1.0.2+3`
+
+Expected output:
+
+```
+  current: 1.0.1+4
+  next:    1.0.2+3
+  tag:     prod-us-v1.0.2+3
+  (tag will not be pushed)
+
+Apply? [y/N] ✓ pubspec.yaml updated to 1.0.2+3
+✓ git tag prod-us-v1.0.2+3 created
+```
+
+> **Note:** Each environment maintains an independent build number sequence, derived from that environment's latest tag — not from the pubspec build number.
+
+---
+
+## Reset
+
+To start fresh, run:
+
+```bash
+bash setup.sh
+```
+
+This wipes the local `.git` directory and resets `pubspec.yaml` back to `1.0.0+1`.
+
+---
+
+## Why `--no-push`?
+
+This example repo has no remote configured. Always pass `--no-push` when running `fro bump` here, otherwise the command will fail trying to push to a non-existent remote.

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,0 +1,8 @@
+name: example
+description: Minimal pubspec for demonstrating the fro CLI.
+publish_to: none
+
+version: 1.0.0+1
+
+environment:
+  sdk: '>=3.4.0 <4.0.0'

--- a/example/setup.sh
+++ b/example/setup.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Resets the example project to its initial state.
+# For first-time setup, follow the instructions in README.md instead.
+set -euo pipefail
+
+if [[ ! -f pubspec.yaml ]]; then
+  echo "Error: run this script from the example/ directory" >&2
+  exit 1
+fi
+
+if [[ ! -d .git ]]; then
+  echo "Error: no .git found — run first-time setup from README.md first" >&2
+  exit 1
+fi
+
+echo "Resetting example project..."
+rm -rf .git
+sed -i '' 's/^version: .*/version: 1.0.0+1/' pubspec.yaml
+
+git init -b main
+git add .
+git commit -m "chore: initial example project"
+git tag prod-v0.9.0+3
+git tag prod-us-v0.8.0+2
+
+echo ""
+echo "Reset complete. Seeded tags:"
+git tag -l | sort


### PR DESCRIPTION
## Summary

- Adds `example/pubspec.yaml` — minimal pubspec at `1.0.0+1` for `fro` to parse
- Adds `example/setup.sh` — reset script that wipes `.git` and re-seeds historical tags (`prod-v0.9.0+3`, `prod-us-v0.8.0+2`)
- Adds `example/README.md` — step-by-step walkthrough with exact expected CLI output for `fro check` and `fro bump`

Closes #3

## Test plan

- [ ] `cd example && git init -b main && git add . && git commit -m "chore: initial example project" && git tag prod-v0.9.0+3 && git tag prod-us-v0.8.0+2`
- [ ] `fro check` → `pubspec: 1.0.0+1`
- [ ] `fro check --env=prod` → shows `✗ not tagged yet`
- [ ] `fro bump --env=prod --strategy=patch --no-push` → bumps to `1.0.1+4`, tag `prod-v1.0.1+4`
- [ ] `fro bump --env=prod-us --strategy=patch --no-push` → bumps to `1.0.2+3`, tag `prod-us-v1.0.2+3`
- [ ] `bash setup.sh` → resets cleanly back to `1.0.0+1`